### PR TITLE
Included Privileges carbon module

### DIFF
--- a/Lib/Carbon/Privileges/Get-Privilege.ps1
+++ b/Lib/Carbon/Privileges/Get-Privilege.ps1
@@ -1,0 +1,54 @@
+# Copyright 2012 Aaron Jensen
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function Get-Privilege
+{
+    <#
+    .SYNOPSIS
+    Gets an identity's privileges.
+    
+    .DESCRIPTION
+    These privileges are usually managed by Group Policy and control the system operations and types of logons a user/group can perform.
+    
+    Note: if a computer is not on a domain, this function won't work.
+    
+    .OUTPUTS
+    System.String
+    
+    .LINK
+    Grant-Privilege
+    
+    .LINK
+    Revoke-Prvileges
+    
+    .LINK
+    Test-Privilege
+    
+    .EXAMPLE
+    Get-Privilege -Identity TheBeast
+    
+    Gets `TheBeast`'s privileges as an array of strings.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        # The identity whose privileges to return.
+        $Identity
+    )
+    
+    [Carbon.Lsa]::GetPrivileges( $Identity )
+}
+
+Set-Alias -Name 'Get-Privileges' -Value 'Get-Privilege'

--- a/Lib/Carbon/Privileges/Grant-Privilege.ps1
+++ b/Lib/Carbon/Privileges/Grant-Privilege.ps1
@@ -1,0 +1,142 @@
+# Copyright 2012 Aaron Jensen
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function Grant-Privilege
+{
+    <#
+    .SYNOPSIS
+    Grants an identity priveleges to perform system operations.
+    
+    .DESCRIPTION
+    *Privilege names are **case-sensitive**.* Valid privileges are documented on Microsoft's website: [Privilege Constants](http://msdn.microsoft.com/en-us/library/windows/desktop/bb530716.aspx) and [Account Right Constants](http://msdn.microsoft.com/en-us/library/windows/desktop/bb545671.aspx). Here is the most current list, as of August 2014:
+
+     * SeAssignPrimaryTokenPrivilege
+     * SeAuditPrivilege
+     * SeBackupPrivilege
+     * SeBatchLogonRight
+     * SeChangeNotifyPrivilege
+     * SeCreateGlobalPrivilege
+     * SeCreatePagefilePrivilege
+     * SeCreatePermanentPrivilege
+     * SeCreateSymbolicLinkPrivilege
+     * SeCreateTokenPrivilege
+     * SeDebugPrivilege
+     * SeDenyBatchLogonRight
+     * SeDenyInteractiveLogonRight
+     * SeDenyNetworkLogonRight
+     * SeDenyRemoteInteractiveLogonRight
+     * SeDenyServiceLogonRight
+     * SeEnableDelegationPrivilege
+     * SeImpersonatePrivilege
+     * SeIncreaseBasePriorityPrivilege
+     * SeIncreaseQuotaPrivilege
+     * SeIncreaseWorkingSetPrivilege
+     * SeInteractiveLogonRight
+     * SeLoadDriverPrivilege
+     * SeLockMemoryPrivilege
+     * SeMachineAccountPrivilege
+     * SeManageVolumePrivilege
+     * SeNetworkLogonRight
+     * SeProfileSingleProcessPrivilege
+     * SeRelabelPrivilege
+     * SeRemoteInteractiveLogonRight
+     * SeRemoteShutdownPrivilege
+     * SeRestorePrivilege
+     * SeSecurityPrivilege
+     * SeServiceLogonRight
+     * SeShutdownPrivilege
+     * SeSyncAgentPrivilege
+     * SeSystemEnvironmentPrivilege
+     * SeSystemProfilePrivilege
+     * SeSystemtimePrivilege
+     * SeTakeOwnershipPrivilege
+     * SeTcbPrivilege
+     * SeTimeZonePrivilege
+     * SeTrustedCredManAccessPrivilege
+     * SeUndockPrivilege
+     * SeUnsolicitedInputPrivilege
+
+    .LINK
+    Get-Privilege
+    
+    .LINK
+    Revoke-Privilege
+    
+    .LINK
+    Test-Privilege
+    
+    .LINK
+    http://msdn.microsoft.com/en-us/library/windows/desktop/bb530716.aspx
+    
+    .LINK
+    http://msdn.microsoft.com/en-us/library/windows/desktop/bb545671.aspx
+    
+    .EXAMPLE
+    Grant-Privilege -Identity Batcomputer -Privilege SeServiceLogonRight
+    
+    Grants the Batcomputer account the ability to logon as a service. *Privilege names are **case-sensitive**.*
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        # The identity to grant a privilege.
+        $Identity,
+        
+        [Parameter(Mandatory=$true)]
+        [string[]]
+        # The privileges to grant. *Privilege names are **case-sensitive**.*
+        $Privilege
+    )
+    
+    if( -not (Test-Identity -Name $Identity) )
+    {
+        Write-Error -Message ('[Carbon] [Grant-Privilege] Identity {0} not found.' -f $Identity) `
+                    -Category ObjectNotFound
+        return
+    }
+    
+    try
+    {
+        [Carbon.Lsa]::GrantPrivileges( $Identity, $Privilege )
+    }
+    catch
+    {
+        $ex = $_.Exception
+        do
+        {
+            if( $ex -is [ComponentModel.Win32Exception] -and $ex.Message -eq 'No such privilege. Indicates a specified privilege does not exist.' )
+            {
+                $msg = 'Failed to grant {0} {1} privilege(s): {2}  *Privilege names are **case-sensitive**.*' -f `
+                        $Identity,($Privilege -join ','),$ex.Message
+                Write-Error -Message $msg
+                return
+            }
+            else
+            {
+                $ex = $ex.InnerException
+            }
+        }
+        while( $ex )
+
+        $ex = $_.Exception        
+        Write-Error -Message ('Failed to grant {0} {1} privilege(s): {2}' -f $Identity,($Privilege -join ', '),$ex.Message)
+        
+        while( $ex.InnerException )
+        {
+            $ex = $ex.InnerException
+            Write-Error -Exception $ex
+        }
+    }
+}

--- a/Lib/Carbon/Privileges/Revoke-Privilege.ps1
+++ b/Lib/Carbon/Privileges/Revoke-Privilege.ps1
@@ -1,0 +1,135 @@
+# Copyright 2012 Aaron Jensen
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function Revoke-Privilege
+{
+    <#
+    .SYNOPSIS
+    Revokes an identity's privileges to perform system operations and certain types of logons.
+    
+    .DESCRIPTION
+    Valid privileges are documented on Microsoft's website: [Privilege Constants](http://msdn.microsoft.com/en-us/library/windows/desktop/bb530716.aspx) and [Account Right Constants](http://msdn.microsoft.com/en-us/library/windows/desktop/bb545671.aspx). Known values as of August 2014 are:
+
+     * SeAssignPrimaryTokenPrivilege
+     * SeAuditPrivilege
+     * SeBackupPrivilege
+     * SeBatchLogonRight
+     * SeChangeNotifyPrivilege
+     * SeCreateGlobalPrivilege
+     * SeCreatePagefilePrivilege
+     * SeCreatePermanentPrivilege
+     * SeCreateSymbolicLinkPrivilege
+     * SeCreateTokenPrivilege
+     * SeDebugPrivilege
+     * SeDenyBatchLogonRight
+     * SeDenyInteractiveLogonRight
+     * SeDenyNetworkLogonRight
+     * SeDenyRemoteInteractiveLogonRight
+     * SeDenyServiceLogonRight
+     * SeEnableDelegationPrivilege
+     * SeImpersonatePrivilege
+     * SeIncreaseBasePriorityPrivilege
+     * SeIncreaseQuotaPrivilege
+     * SeIncreaseWorkingSetPrivilege
+     * SeInteractiveLogonRight
+     * SeLoadDriverPrivilege
+     * SeLockMemoryPrivilege
+     * SeMachineAccountPrivilege
+     * SeManageVolumePrivilege
+     * SeNetworkLogonRight
+     * SeProfileSingleProcessPrivilege
+     * SeRelabelPrivilege
+     * SeRemoteInteractiveLogonRight
+     * SeRemoteShutdownPrivilege
+     * SeRestorePrivilege
+     * SeSecurityPrivilege
+     * SeServiceLogonRight
+     * SeShutdownPrivilege
+     * SeSyncAgentPrivilege
+     * SeSystemEnvironmentPrivilege
+     * SeSystemProfilePrivilege
+     * SeSystemtimePrivilege
+     * SeTakeOwnershipPrivilege
+     * SeTcbPrivilege
+     * SeTimeZonePrivilege
+     * SeTrustedCredManAccessPrivilege
+     * SeUndockPrivilege
+     * SeUnsolicitedInputPrivilege
+
+    .LINK
+    Get-Privilege
+    
+    .LINK
+    Grant-Privilege
+    
+    .LINK
+    Test-Privilege
+    
+    .LINK
+    http://msdn.microsoft.com/en-us/library/windows/desktop/bb530716.aspx
+    
+    .LINK
+    http://msdn.microsoft.com/en-us/library/windows/desktop/bb545671.aspx
+    
+    .EXAMPLE
+    Revoke-Privilege -Identity Batcomputer -Privilege SeServiceLogonRight
+    
+    Revokes the Batcomputer account's ability to logon as a service.  Don't restart that thing!
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        # The identity to grant a privilege.
+        $Identity,
+        
+        [Parameter(Mandatory=$true)]
+        [string[]]
+        # The privileges to revoke.
+        $Privilege
+    )
+    
+    Set-StrictMode -Version Latest
+    
+    if( -not (Test-Identity -Name $Identity) )
+    {
+        Write-Error -Message ('[Carbon] [Revoke-Privilege] Identity {0} not found.' -f $identity) `
+                    -Category ObjectNotFound
+        return
+    }
+    
+    # Convert the privileges from the user into their canonical names.
+    $cPrivileges = Get-Privilege -Identity $Identity |
+                        Where-Object { $Privilege -contains $_ }
+    if( -not $cPrivileges )
+    {
+        return
+    }
+    
+    try
+    {
+        [Carbon.Lsa]::RevokePrivileges($Identity,$cPrivileges)
+    }
+    catch
+    {
+        Write-Error -Message ('Failed to revoke {0}''s {1} privilege(s).' -f $Identity,($cPrivileges -join ', ')) 
+
+        $ex = $_.Exception
+        while( $ex.InnerException )
+        {
+            $ex = $ex.InnerException
+            Write-Error -Exception $ex
+        }
+    }
+}

--- a/Lib/Carbon/Privileges/Test-Privilege.ps1
+++ b/Lib/Carbon/Privileges/Test-Privilege.ps1
@@ -1,0 +1,54 @@
+# Copyright 2012 Aaron Jensen
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function Test-Privilege
+{
+    <#
+    .SYNOPSIS
+    Tests if an identity has a given privilege.
+    
+    .DESCRIPTION
+    Returns `true` if an identity has a privilege.  `False` otherwise.
+
+    .LINK
+    Get-Privilege
+
+    .LINK
+    Grant-Privilege
+
+    .LINK
+    Revoke-Privilege
+    
+    .EXAMPLE
+    Test-Privilege -Identity Forrester -Privilege SeServiceLogonRight
+    
+    Tests if `Forrester` has the `SeServiceLogonRight` privilege.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        # The identity whose privileges to check.
+        $Identity,
+        
+        [Parameter(Mandatory=$true)]
+        [string]
+        # The privilege to check.
+        $Privilege
+    )
+    
+    $matchingPrivilege = Get-Privilege -Identity $Identity |
+                            Where-Object { $_ -eq $Privilege }
+    return ($matchingPrivilege -ne $null)
+}

--- a/YInstall/Tasks/WindowsService.ps1
+++ b/YInstall/Tasks/WindowsService.ps1
@@ -5,6 +5,7 @@ task WindowsService{
     . Add-CarbonModule Security
     . Add-CarbonModule UsersAndGroups
     . Add-CarbonModule Service
+    . Add-CarbonModule Privileges
 
     $artifactsDir = Get-Conventions artifactsDir
     $taskConfig = Get-InstallTaskConfiguration


### PR DESCRIPTION
The ```Install-Service``` task is dependent on the privileges module to execute ```Grant-Privilege``` task if the service is to be installed as a different user. Hence, added the carbon module as a dependency to WindowsServiceTask.